### PR TITLE
fix: update gnome-shell and mutter for CentOS 10 manually

### DIFF
--- a/archlinux.dockerfile
+++ b/archlinux.dockerfile
@@ -7,7 +7,7 @@ ARG GNOME_SHELL_VERSION=1:49.4-2
 ARG MUTTER_VERSION=49.4-1
 
 # renovate: datasource=custom.repology depName=gjs packageName=gjs[repo='arch']
-ARG GJS_VERSION=2:1.86.0-1
+ARG GJS_VERSION=2:1.86.0-2
 
 # renovate: datasource=custom.repology depName=vte packageName=vte[repo='arch']
 ARG VTE_VERSION=0.82.3-1

--- a/centos-10.dockerfile
+++ b/centos-10.dockerfile
@@ -1,10 +1,10 @@
 FROM quay.io/centos/centos:10
 
 # renovate: datasource=custom.repology depName=gnome-shell packageName=gnome-shell[repo='centos_stream_10']
-ARG GNOME_SHELL_VERSION=47.10-1.el10
+ARG GNOME_SHELL_VERSION=49.4-2.el10
 
 # renovate: datasource=custom.repology depName=mutter packageName=mutter[repo='centos_stream_10']
-ARG MUTTER_VERSION=47.5-13.el10
+ARG MUTTER_VERSION=49.4-3.el10
 
 # renovate: datasource=custom.repology depName=gjs packageName=gjs[repo='centos_stream_10']
 ARG GJS_VERSION=1.80.2-11.el10

--- a/fedora-43.dockerfile
+++ b/fedora-43.dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/fedora/fedora:43
 
 # renovate: datasource=custom.repology depName=gnome-shell packageName=gnome-shell[repo='fedora_43']
-ARG GNOME_SHELL_VERSION=49.4-1.fc43
+ARG GNOME_SHELL_VERSION=49.4-2.fc43
 
 # renovate: datasource=custom.repology depName=mutter packageName=mutter[repo='fedora_43']
 ARG MUTTER_VERSION=49.4-1.fc43


### PR DESCRIPTION
Renovate didn't update them because of wrong versioning.